### PR TITLE
ENH: some utilities for plcprog-console local hooks

### DIFF
--- a/forTwinCatRepos/local/.pre-commit-config.yaml
+++ b/forTwinCatRepos/local/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: local
+  hooks:
+  - id: twincat-lineids-remover
+    name: TwinCAT LineID Remover
+    description: Eliminate TwinCAT line ID lines
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/twincat_lineids_remover.py
+    language: python
+    files: .*\.TcPOU$
+  - id: leading-tabs-remover
+    name: Leading Tabs Remover
+    description: Replace leading tabs with 4 spaces
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/leading_tabs_remover.py
+    language: python
+  - id: twincat-leading-tabs-remover
+    name: TwinCAT Leading Tabs Remover
+    description: leading-tabs-remover configured for TwinCAT
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/leading_tabs_remover.py
+    language: python
+    files: .*\.(TcPOU|TcDUT|TcGVL)$
+  - id: xml-format
+    name: XML Formatter
+    description: Use lxml to beautify xml files
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/xml_format.py
+    language: python
+    types: [xml]
+  - id: twincat-xml-format
+    name: TwinCAT XML Formatter
+    description: xml-format configured for TwinCAT
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/xml_format.py
+    language: python
+    files: .*\.(tmc|tpy|xml)$
+  - id: trailing-whitespace
+    files: \.(TcPOU|TcDUT|TcGVL)$
+    description: Fix trailing whitespace for TwinCAT source
+    name: Trailing whitespace
+    entry: C:/repos/pcds-pre-commit-hooks/pre_commit_hooks/trailing_whitespace_fixer.py
+    language: python

--- a/forTwinCatRepos/local/commit-helper.cmd
+++ b/forTwinCatRepos/local/commit-helper.cmd
@@ -1,0 +1,2 @@
+C:\miniconda\scripts\conda activate plc-pre-commit
+C:\miniconda\envs\plc-pre-commit\scripts\pre-commit run --all-files -c C:\repos\pcds-pre-commit-hooks\forTwinCatRepos\local\.pre-commit-config.yaml

--- a/pre_commit_hooks/leading_tabs_remover.py
+++ b/pre_commit_hooks/leading_tabs_remover.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import re
 

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+from typing import Optional
+from typing import Sequence
+
+
+def _fix_file(
+        filename: str,
+        is_markdown: bool,
+        chars: Optional[bytes],
+) -> bool:
+    with open(filename, mode='rb') as file_processed:
+        lines = file_processed.readlines()
+    newlines = [_process_line(line, is_markdown, chars) for line in lines]
+    if newlines != lines:
+        with open(filename, mode='wb') as file_processed:
+            for line in newlines:
+                file_processed.write(line)
+        return True
+    else:
+        return False
+
+
+def _process_line(
+        line: bytes,
+        is_markdown: bool,
+        chars: Optional[bytes],
+) -> bytes:
+    if line[-2:] == b'\r\n':
+        eol = b'\r\n'
+        line = line[:-2]
+    elif line[-1:] == b'\n':
+        eol = b'\n'
+        line = line[:-1]
+    else:
+        eol = b''
+    # preserve trailing two-space for non-blank lines in markdown files
+    if is_markdown and (not line.isspace()) and line.endswith(b'  '):
+        return line[:-2].rstrip(chars) + b'  ' + eol
+    return line.rstrip(chars) + eol
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--no-markdown-linebreak-ext',
+        action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        '--markdown-linebreak-ext',
+        action='append',
+        default=[],
+        metavar='*|EXT[,EXT,...]',
+        help=(
+            'Markdown extensions (or *) to not strip linebreak spaces.  '
+            'default: %(default)s'
+        ),
+    )
+    parser.add_argument(
+        '--chars',
+        help=(
+            'The set of characters to strip from the end of lines.  '
+            'Defaults to all whitespace characters.'
+        ),
+    )
+    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    args = parser.parse_args(argv)
+
+    if args.no_markdown_linebreak_ext:
+        print('--no-markdown-linebreak-ext now does nothing!')
+
+    md_args = args.markdown_linebreak_ext
+    if '' in md_args:
+        parser.error('--markdown-linebreak-ext requires a non-empty argument')
+    all_markdown = '*' in md_args
+    # normalize extensions; split at ',', lowercase, and force 1 leading '.'
+    md_exts = [
+        '.' + x.lower().lstrip('.') for x in ','.join(md_args).split(',')
+    ]
+
+    # reject probable "eaten" filename as extension: skip leading '.' with [1:]
+    for ext in md_exts:
+        if any(c in ext[1:] for c in r'./\:'):
+            parser.error(
+                f'bad --markdown-linebreak-ext extension '
+                f'{ext!r} (has . / \\ :)\n'
+                f"  (probably filename; use '--markdown-linebreak-ext=EXT')",
+            )
+    chars = None if args.chars is None else args.chars.encode()
+    return_code = 0
+    for filename in args.filenames:
+        _, extension = os.path.splitext(filename.lower())
+        md = all_markdown or extension in md_exts
+        if _fix_file(filename, md, chars):
+            print(f'Fixing {filename}')
+            return_code = 1
+    return return_code
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/pre_commit_hooks/twincat_lineids_remover.py
+++ b/pre_commit_hooks/twincat_lineids_remover.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 
 

--- a/pre_commit_hooks/xml_format.py
+++ b/pre_commit_hooks/xml_format.py
@@ -1,3 +1,5 @@
+#!C:/miniconda/envs/plc-pre-commit/python.exe
+
 import argparse
 
 from lxml import etree


### PR DESCRIPTION
* Vendors trailing_whitespace_fixer.py but ties it to plcprog-console directory structures (TODO)
* Adds `commit-helper`
* Adjusts hashbang on all python scripts

TODO Investigate https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories