### PR TITLE
MAINT: switch both references from gitlab to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
     -   id: flake8

--- a/forPythonRepos/.pre-commit-config.yaml
+++ b/forPythonRepos/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
     -   id: flake8


### PR DESCRIPTION
pycqa is no longer supporting the gitlab mirror, which was originally the main repo, which is why the stale reference here points to the dead mirror