### PR TITLE
ENH: add pytmc pragmalint pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -33,3 +33,10 @@
   entry: check-fixed-library-versions
   language: python
   files: .*\.plcproj$
+- id: pytmc-pragma-linter
+  name: pytmc-pragma-linter
+  description: Lint pytmc pragmas
+  entry: bash -c 'set -ex; for fn in "$@"; do pytmc pragmalint "$fn"; done' --
+  language: python
+  files: .*\.(TcPOU|TcGVL)$
+  additional_dependencies: ["pytmc"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -38,5 +38,5 @@
   description: Lint pytmc pragmas
   entry: bash -c 'set -ex; for fn in "$@"; do pytmc pragmalint "$fn"; done' --
   language: python
-  files: .*\.(TcPOU|TcGVL)$
+  files: .*\.(TcPOU|TcGVL|TcDUT)$
   additional_dependencies: ["pytmc"]

--- a/forTwinCatRepos/.pre-commit-config.yaml
+++ b/forTwinCatRepos/.pre-commit-config.yaml
@@ -15,3 +15,5 @@ repos:
     -   id: twincat-lineids-remover
     -   id: twincat-xml-format
     -   id: check-fixed-library-versions
+    # Optional, if you use pytmc to generate EPICS IOCs:
+    # -   id: pytmc-pragma-linter


### PR DESCRIPTION
Closes #20 

Sample output - while not pretty, it appears functional and useful:

```
pytmc-pragma-linter......................................................Failed
- hook id: pytmc-pragma-linter
- exit code: 1

+ for fn in "$@"
+ pytmc pragmalint LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU
ERROR:pytmc.bin.pragmalint:Linter error: Unhandled exception: Found invalid pragma line(s):
    |         pv: NAME
    |         io: iofoob
    |       field: DESC Descriptive name for the LED
--> |       pragamama : lint
    |         autosave_pass0: VAL DESC
--> |
LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU:line 21:     {attribute 'pytmc' := '
            pv: NAME
            io: iofoob
          field: DESC Descriptive name for the LED
          pragamama : lint
            autosave_pass0: VAL DESC
        '}
ERROR:pytmc.bin.pragmalint:Unhandled exception (may be a pytmc bug)
Traceback (most recent call last):
  File "/Users/klauer/.cache/pre-commit/repoznchl_6k/py_env-python3.11/lib/python3.11/site-packages/pytmc/bin/pragmalint.py", line 253, in lint_source
    lint_pragma(pragma)
  File "/Users/klauer/.cache/pre-commit/repoznchl_6k/py_env-python3.11/lib/python3.11/site-packages/pytmc/bin/pragmalint.py", line 131, in lint_pragma
    pragmas.split_pytmc_pragma(pragma_setting)
  File "/Users/klauer/.cache/pre-commit/repoznchl_6k/py_env-python3.11/lib/python3.11/site-packages/pytmc/pragmas.py", line 95, in split_pytmc_pragma
    raise ValueError(f"Found invalid pragma line(s):\n{invalid_lines}")
ValueError: Found invalid pragma line(s):
    |         pv: NAME
    |         io: iofoob
    |       field: DESC Descriptive name for the LED
--> |       pragamama : lint
    |         autosave_pass0: VAL DESC
--> |
INFO:pytmc.bin.pragmalint:Total pragmas found: 3 Total linter errors: 1
```

On a separate note, it looks like pytmc's linter output needs some work...