### PR TITLE
add product version check pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,3 +40,9 @@
   language: python
   files: .*\.(TcPOU|TcGVL|TcDUT)$
   additional_dependencies: ["pytmc"]
+- id: no-product-version
+  name: Check for product version
+  description: Checks if the product version is saved in the TwinCAT source file.
+  entry: no-product-version
+  language: python
+  files: .*\.(TcPOU|TcDUT|TcGVL)$

--- a/README.md
+++ b/README.md
@@ -10,9 +10,31 @@ Pre-commit hooks for PCDS projects (https://pre-commit.com/)
 
 ### To install pre-commit hooks to a local repository:
 
-If .pre-config-config.yaml does not already exist in the repository, copy
+If `.pre-config-config.yaml` does not already exist in the repository, copy
 the appropriate file from this repository to the top-level of your local
-repository and commit the addition.
+repository, or add the folowing to an existing `.pre-config-config.yaml` 
+file and commit the addition.
+
+```yaml
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v2.5.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+        files: \.(TcPOU|TcDUT|TcGVL)$
+
+-   repo: https://github.com/pcdshub/pre-commit-hooks.git
+    rev: v1.4.0
+    hooks:
+    -   id: twincat-leading-tabs-remover
+    -   id: twincat-lineids-remover
+    -   id: twincat-xml-format
+    -   id: check-fixed-library-versions
+    -   id: no-product-version
+    # Optional, if you use pytmc to generate EPICS IOCs:
+    # -   id: pytmc-pragma-linter
+```
 
 Once the file is there, run the following from inside your repository:
 ```bash

--- a/forTwinCatRepos/.pre-commit-config.yaml
+++ b/forTwinCatRepos/.pre-commit-config.yaml
@@ -9,11 +9,12 @@ repos:
         files: \.(TcPOU|TcDUT|TcGVL)$
 
 -   repo: https://github.com/pcdshub/pre-commit-hooks.git
-    rev: v1.2.0
+    rev: v1.4.0
     hooks:
     -   id: twincat-leading-tabs-remover
     -   id: twincat-lineids-remover
     -   id: twincat-xml-format
     -   id: check-fixed-library-versions
+    -   id: no-product-version
     # Optional, if you use pytmc to generate EPICS IOCs:
     # -   id: pytmc-pragma-linter

--- a/pre_commit_hooks/no_product_version.py
+++ b/pre_commit_hooks/no_product_version.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import argparse
+
+from lxml import etree
+
+
+class PreCommitException(Exception):
+    pass
+
+
+def check_file(filename):
+    with open(filename, 'rb') as fd:
+        original_xml = fd.read()
+
+    xml_parser = etree.XMLParser(remove_blank_text=True)
+    parse_tree = etree.XML(original_xml, parser=xml_parser).getroottree()
+
+    tc_plc_object = list(parse_tree.iter("TcPlcObject"))[0].attrib
+    # Check if it contains a product version attribute
+    if 'ProductVersion' in tc_plc_object:
+        raise PreCommitException(
+            f"Detected product version ({tc_plc_object['ProductVersion']}) in {filename}. "
+            f"To disable this go to Project settings > Advanced and disable 'Write product version in files.'")
+
+
+def main(args=None):
+    if args is None:
+        parser = argparse.ArgumentParser()
+        parser.add_argument('filenames', nargs='*')
+        args = parser.parse_args()
+    try:
+        for filename in args.filenames:
+            check_file(filename)
+        return 0
+    except Exception as exc:
+        print(exc)
+        return 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ with open('requirements.txt') as fd:
 hook_names = ['twincat-lineids-remover',
               'leading-tabs-remover',
               'xml-format',
-              'check-fixed-library-versions']
+              'check-fixed-library-versions',
+              'no-product-version',
+              ]
 console_scripts = []
 for name in hook_names:
     module = name.replace('-', '_')


### PR DESCRIPTION
A pre-commit to check if the product version is saved in the xml file

```
<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
```

It only fails when it detects the Product version. I thought about automatically removing it as well, but this can be easily done with a single click for all files in the project. And I was not sure what it would do if some files have a product version and others not.