### PR TITLE
Add and run ruff on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
--   repo: https://github.com/pycqa/flake8.git
-    rev: 3.7.9
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
     hooks:
-    -   id: flake8
-
--   repo: https://github.com/timothycrosley/isort.git
-    rev: 4.3.21-2
-    hooks:
-    -   id: isort
+      # Run the linter.
+      - id: ruff
+        # --select I sorts imports
+        args: [ --fix, --select, I  ]
+      # Run the formatter.
+      - id: ruff-format

--- a/pre_commit_hooks/__init__.py
+++ b/pre_commit_hooks/__init__.py
@@ -1,5 +1,4 @@
-
 from ._version import get_versions
 
-__version__ = get_versions()['version']
+__version__ = get_versions()["version"]
 del get_versions

--- a/pre_commit_hooks/_version.py
+++ b/pre_commit_hooks/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/pre_commit_hooks/check_fixed_library_versions.py
+++ b/pre_commit_hooks/check_fixed_library_versions.py
@@ -10,26 +10,35 @@ class PreCommitException(Exception):
 
 
 def check_file(filename):
-    with open(filename, 'rb') as fd:
+    with open(filename, "rb") as fd:
         original_xml = fd.read()
 
     xml_parser = etree.XMLParser(remove_blank_text=True)
     parse_tree = etree.XML(original_xml, parser=xml_parser).getroottree()
 
-    added_libraries = set(el.attrib["Include"] for el in parse_tree.iter("{*}PlaceholderReference"))
-    fixed_version_libraries = set(el.attrib["Include"] for el in parse_tree.iter("{*}PlaceholderResolution"))
+    added_libraries = set(
+        el.attrib["Include"] for el in parse_tree.iter("{*}PlaceholderReference")
+    )
+    fixed_version_libraries = set(
+        el.attrib["Include"] for el in parse_tree.iter("{*}PlaceholderResolution")
+    )
 
     non_fixed_library_versions = added_libraries - fixed_version_libraries
 
     if len(non_fixed_library_versions) == 1:
-        raise PreCommitException(f"Library version of {list(non_fixed_library_versions)[0]} is not fixed!")
+        raise PreCommitException(
+            f"Library version of {list(non_fixed_library_versions)[0]} is not fixed!"
+        )
     elif len(non_fixed_library_versions) > 1:
-        raise PreCommitException(f"Library version of {', '.join(non_fixed_library_versions)} are not fixed!")
+        raise PreCommitException(
+            f"Library version of {', '.join(non_fixed_library_versions)} are not fixed!"
+        )
+
 
 def main(args=None):
     if args is None:
         parser = argparse.ArgumentParser()
-        parser.add_argument('filenames', nargs='*')
+        parser.add_argument("filenames", nargs="*")
         args = parser.parse_args()
     try:
         for filename in args.filenames:

--- a/pre_commit_hooks/leading_tabs_remover.py
+++ b/pre_commit_hooks/leading_tabs_remover.py
@@ -7,33 +7,32 @@ TAB_WIDTH = 4
 
 
 def fix_file(filename, tab_width=TAB_WIDTH):
-    with open(filename, 'r') as fd:
+    with open(filename, "r") as fd:
         original_lines = fd.readlines()
     new_lines = []
     changed = False
     # Match all leading whitespace and group it
-    regex = re.compile(r'^(\s+)')
+    regex = re.compile(r"^(\s+)")
     for line in original_lines:
         match = regex.match(line)
         if match:
             leading_whitespace = match.groups()[0]
             # Fix if leading whitespace contain tabs
-            if '\t' in leading_whitespace:
+            if "\t" in leading_whitespace:
                 changed = True
-                line = (leading_whitespace.replace('\t', ' ' * tab_width)
-                        + line.lstrip())
+                line = leading_whitespace.replace("\t", " " * tab_width) + line.lstrip()
         new_lines.append(line)
     if changed:
-        print(f'Fixing {filename}')
-        with open(filename, 'w') as fd:
-            fd.write(''.join(new_lines))
+        print(f"Fixing {filename}")
+        with open(filename, "w") as fd:
+            fd.write("".join(new_lines))
 
 
 def main(args=None):
     if args is None:
         parser = argparse.ArgumentParser()
-        parser.add_argument('filenames', nargs='*')
-        parser.add_argument('--tab-width', type=int, default=TAB_WIDTH)
+        parser.add_argument("filenames", nargs="*")
+        parser.add_argument("--tab-width", type=int, default=TAB_WIDTH)
         args = parser.parse_args()
     try:
         for filename in args.filenames:

--- a/pre_commit_hooks/minimize_id_changes.py
+++ b/pre_commit_hooks/minimize_id_changes.py
@@ -12,18 +12,19 @@ def minimize_id_changes_checked(filename: Union[Traversable, str]) -> None:
     tree = ET.parse(filename)
     root = tree.getroot()
 
-    combine_ids_element = root.find('.//{*}CombineIds')
+    combine_ids_element = root.find(".//{*}CombineIds")
 
-    if combine_ids_element is None or combine_ids_element.text.lower() == 'false':
+    if combine_ids_element is None or combine_ids_element.text.lower() == "false":
         raise PreCommitException(
             f"Minimize id changes not checked in {filename}. "
-            f"To enable this go to Project settings > Common and select 'Minimize Id changes in TwinCAT files.'")
+            f"To enable this go to Project settings > Common and select 'Minimize Id changes in TwinCAT files.'"
+        )
 
 
 def main(args=None):
     if args is None:
         parser = argparse.ArgumentParser()
-        parser.add_argument('filenames', nargs='*')
+        parser.add_argument("filenames", nargs="*")
         args = parser.parse_args()
     try:
         for filename in args.filenames:

--- a/pre_commit_hooks/no_product_version.py
+++ b/pre_commit_hooks/no_product_version.py
@@ -10,7 +10,7 @@ class PreCommitException(Exception):
 
 
 def check_file(filename):
-    with open(filename, 'rb') as fd:
+    with open(filename, "rb") as fd:
         original_xml = fd.read()
 
     xml_parser = etree.XMLParser(remove_blank_text=True)
@@ -18,16 +18,17 @@ def check_file(filename):
 
     tc_plc_object = list(parse_tree.iter("TcPlcObject"))[0].attrib
     # Check if it contains a product version attribute
-    if 'ProductVersion' in tc_plc_object:
+    if "ProductVersion" in tc_plc_object:
         raise PreCommitException(
             f"Detected product version ({tc_plc_object['ProductVersion']}) in {filename}. "
-            f"To disable this go to Project settings > Advanced and disable 'Write product version in files.'")
+            f"To disable this go to Project settings > Advanced and disable 'Write product version in files.'"
+        )
 
 
 def main(args=None):
     if args is None:
         parser = argparse.ArgumentParser()
-        parser.add_argument('filenames', nargs='*')
+        parser.add_argument("filenames", nargs="*")
         args = parser.parse_args()
     try:
         for filename in args.filenames:

--- a/pre_commit_hooks/tests/data/minimize-id-changes-enabled.plcproj
+++ b/pre_commit_hooks/tests/data/minimize-id-changes-enabled.plcproj
@@ -91,4 +91,3 @@
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>
-

--- a/pre_commit_hooks/tests/data/no-minimize-id-changes.plcproj
+++ b/pre_commit_hooks/tests/data/no-minimize-id-changes.plcproj
@@ -89,4 +89,3 @@
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>
-

--- a/pre_commit_hooks/tests/test_minimize_id_changes.py
+++ b/pre_commit_hooks/tests/test_minimize_id_changes.py
@@ -1,9 +1,12 @@
 from importlib.resources import files
 
-import pre_commit_hooks.tests.data as test_data
 import pytest
-from pre_commit_hooks.minimize_id_changes import (PreCommitException,
-                                                  minimize_id_changes_checked)
+
+import pre_commit_hooks.tests.data as test_data
+from pre_commit_hooks.minimize_id_changes import (
+    PreCommitException,
+    minimize_id_changes_checked,
+)
 
 
 def test_missing_minimize_id_changes():

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -2,20 +2,19 @@
 
 import argparse
 import os
-from typing import Optional
-from typing import Sequence
+from typing import Optional, Sequence
 
 
 def _fix_file(
-        filename: str,
-        is_markdown: bool,
-        chars: Optional[bytes],
+    filename: str,
+    is_markdown: bool,
+    chars: Optional[bytes],
 ) -> bool:
-    with open(filename, mode='rb') as file_processed:
+    with open(filename, mode="rb") as file_processed:
         lines = file_processed.readlines()
     newlines = [_process_line(line, is_markdown, chars) for line in lines]
     if newlines != lines:
-        with open(filename, mode='wb') as file_processed:
+        with open(filename, mode="wb") as file_processed:
             for line in newlines:
                 file_processed.write(line)
         return True
@@ -24,69 +23,67 @@ def _fix_file(
 
 
 def _process_line(
-        line: bytes,
-        is_markdown: bool,
-        chars: Optional[bytes],
+    line: bytes,
+    is_markdown: bool,
+    chars: Optional[bytes],
 ) -> bytes:
-    if line[-2:] == b'\r\n':
-        eol = b'\r\n'
+    if line[-2:] == b"\r\n":
+        eol = b"\r\n"
         line = line[:-2]
-    elif line[-1:] == b'\n':
-        eol = b'\n'
+    elif line[-1:] == b"\n":
+        eol = b"\n"
         line = line[:-1]
     else:
-        eol = b''
+        eol = b""
     # preserve trailing two-space for non-blank lines in markdown files
-    if is_markdown and (not line.isspace()) and line.endswith(b'  '):
-        return line[:-2].rstrip(chars) + b'  ' + eol
+    if is_markdown and (not line.isspace()) and line.endswith(b"  "):
+        return line[:-2].rstrip(chars) + b"  " + eol
     return line.rstrip(chars) + eol
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--no-markdown-linebreak-ext',
-        action='store_true',
+        "--no-markdown-linebreak-ext",
+        action="store_true",
         help=argparse.SUPPRESS,
     )
     parser.add_argument(
-        '--markdown-linebreak-ext',
-        action='append',
+        "--markdown-linebreak-ext",
+        action="append",
         default=[],
-        metavar='*|EXT[,EXT,...]',
+        metavar="*|EXT[,EXT,...]",
         help=(
-            'Markdown extensions (or *) to not strip linebreak spaces.  '
-            'default: %(default)s'
+            "Markdown extensions (or *) to not strip linebreak spaces.  "
+            "default: %(default)s"
         ),
     )
     parser.add_argument(
-        '--chars',
+        "--chars",
         help=(
-            'The set of characters to strip from the end of lines.  '
-            'Defaults to all whitespace characters.'
+            "The set of characters to strip from the end of lines.  "
+            "Defaults to all whitespace characters."
         ),
     )
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     if args.no_markdown_linebreak_ext:
-        print('--no-markdown-linebreak-ext now does nothing!')
+        print("--no-markdown-linebreak-ext now does nothing!")
 
     md_args = args.markdown_linebreak_ext
-    if '' in md_args:
-        parser.error('--markdown-linebreak-ext requires a non-empty argument')
-    all_markdown = '*' in md_args
+    if "" in md_args:
+        parser.error("--markdown-linebreak-ext requires a non-empty argument")
+    all_markdown = "*" in md_args
     # normalize extensions; split at ',', lowercase, and force 1 leading '.'
-    md_exts = [
-        '.' + x.lower().lstrip('.') for x in ','.join(md_args).split(',')
-    ]
+    md_exts = ["." + x.lower().lstrip(".") for x in ",".join(md_args).split(",")]
 
     # reject probable "eaten" filename as extension: skip leading '.' with [1:]
     for ext in md_exts:
-        if any(c in ext[1:] for c in r'./\:'):
+        if any(c in ext[1:] for c in r"./\:"):
             parser.error(
-                f'bad --markdown-linebreak-ext extension '
-                f'{ext!r} (has . / \\ :)\n'
+                f"bad --markdown-linebreak-ext extension "
+                f"{ext!r} (has . / \\ :)\n"
                 f"  (probably filename; use '--markdown-linebreak-ext=EXT')",
             )
     chars = None if args.chars is None else args.chars.encode()
@@ -95,10 +92,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         _, extension = os.path.splitext(filename.lower())
         md = all_markdown or extension in md_exts
         if _fix_file(filename, md, chars):
-            print(f'Fixing {filename}')
+            print(f"Fixing {filename}")
             return_code = 1
     return return_code
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(main())

--- a/pre_commit_hooks/twincat_lineids_remover.py
+++ b/pre_commit_hooks/twincat_lineids_remover.py
@@ -4,27 +4,27 @@ import argparse
 
 
 def fix_file(filename):
-    with open(filename, 'r') as fd:
+    with open(filename, "r") as fd:
         original_lines = fd.readlines()
     new_lines = []
     changed = False
 
     for line in original_lines:
-        if '<LineId' in line or 'LineIds>' in line:
+        if "<LineId" in line or "LineIds>" in line:
             changed = True
         else:
             new_lines.append(line)
 
     if changed:
-        print(f'Fixing {filename}')
-        with open(filename, 'w') as fd:
-            fd.write(''.join(new_lines))
+        print(f"Fixing {filename}")
+        with open(filename, "w") as fd:
+            fd.write("".join(new_lines))
 
 
 def main(args=None):
     if args is None:
         parser = argparse.ArgumentParser()
-        parser.add_argument('filenames', nargs='*')
+        parser.add_argument("filenames", nargs="*")
         args = parser.parse_args()
     try:
         for filename in args.filenames:

--- a/pre_commit_hooks/twincat_st_newline.py
+++ b/pre_commit_hooks/twincat_st_newline.py
@@ -1,26 +1,29 @@
 import argparse
+
 from lxml import etree
+
 
 def structured_text_formatter(path: str, lines: int = 1) -> None:
     root = etree.parse(path).getroot()
-    sect = root.xpath('.//Declaration|.//Implementation/ST')
+    sect = root.xpath(".//Declaration|.//Implementation/ST")
     if len(sect) == 0:
         return
 
-    newlines = '\n' * lines
+    newlines = "\n" * lines
     for section in sect:
         try:
-            section.text = etree.CDATA(newlines + section.text.strip('\n') + newlines)
+            section.text = etree.CDATA(newlines + section.text.strip("\n") + newlines)
         except AttributeError:
             pass
-    etree.ElementTree(root).write(path, encoding='utf-8', xml_declaration=True)
+    etree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--lines', type=int, default=1)
-    parser.add_argument('files', nargs='*')
+    parser.add_argument("--lines", type=int, default=1)
+    parser.add_argument("files", nargs="*")
     args = parser.parse_args()
-    
+
     try:
         for file in args.files:
             structured_text_formatter(file, args.lines)

--- a/pre_commit_hooks/xml_format.py
+++ b/pre_commit_hooks/xml_format.py
@@ -47,15 +47,17 @@ def xml_once(original_xml: str, tab_width: int) -> str:
     xml_parser = etree.XMLParser(remove_blank_text=True)
     parse_tree = etree.XML(original_xml, parser=xml_parser).getroottree()
     etree.indent(parse_tree, space=" " * tab_width)
-    new_xml = etree.tostring(parse_tree,
-                             pretty_print=True,
-                             xml_declaration=True,
-                             encoding=parse_tree.docinfo.encoding)
+    new_xml = etree.tostring(
+        parse_tree,
+        pretty_print=True,
+        xml_declaration=True,
+        encoding=parse_tree.docinfo.encoding,
+    )
 
     # lxml does not preserve line endings, so we must do it ourselves.
     # lxml always outputs with unix line endings (LF)
-    if b'\r\n' in original_xml:
-        new_xml = new_xml.replace(b'\n', b'\r\n')
+    if b"\r\n" in original_xml:
+        new_xml = new_xml.replace(b"\n", b"\r\n")
     return new_xml
 
 
@@ -75,5 +77,5 @@ def main(args=None):
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(main())

--- a/setup.py
+++ b/setup.py
@@ -2,29 +2,31 @@ from setuptools import find_packages, setup
 
 import versioneer
 
-with open('requirements.txt') as fd:
+with open("requirements.txt") as fd:
     requirements = [fd.read().splitlines()]
 
-hook_names = ['twincat-lineids-remover',
-              'leading-tabs-remover',
-              'xml-format',
-              'check-fixed-library-versions',
-              'no-product-version',
-              'twincat-st-newline',
-              'minimize-id-changes',
-              ]
+hook_names = [
+    "twincat-lineids-remover",
+    "leading-tabs-remover",
+    "xml-format",
+    "check-fixed-library-versions",
+    "no-product-version",
+    "twincat-st-newline",
+    "minimize-id-changes",
+]
 console_scripts = []
 for name in hook_names:
-    module = name.replace('-', '_')
-    console_scripts.append(f'{name}=pre_commit_hooks.{module}:main')
+    module = name.replace("-", "_")
+    console_scripts.append(f"{name}=pre_commit_hooks.{module}:main")
 
-setup(name='pre-commit-hooks',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      author='SLAC National Accelerator Laboratory',
-      packages=find_packages(),
-      include_package_data=True,
-      install_requires=requirements,
-      description='SLAC LCLS custom pre-commit-hooks',
-      entry_points={'console_scripts': console_scripts},
-      )
+setup(
+    name="pre-commit-hooks",
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    author="SLAC National Accelerator Laboratory",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=requirements,
+    description="SLAC LCLS custom pre-commit-hooks",
+    entry_points={"console_scripts": console_scripts},
+)

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -310,11 +309,13 @@ def get_root():
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        err = ("Versioneer was unable to run the project root directory. "
-               "Versioneer requires setup.py to be executed from "
-               "its immediate directory (like 'python setup.py COMMAND'), "
-               "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+        err = (
+            "Versioneer was unable to run the project root directory. "
+            "Versioneer requires setup.py to be executed from "
+            "its immediate directory (like 'python setup.py COMMAND'), "
+            "or in a way that lets it use sys.argv[0] to find the root "
+            "(like 'python path/to/setup.py COMMAND')."
+        )
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
@@ -327,8 +328,10 @@ def get_root():
         me_dir = os.path.normcase(os.path.splitext(me)[0])
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
-            print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(me), versioneer_py))
+            print(
+                "Warning: build in %s is using versioneer.py from %s"
+                % (os.path.dirname(me), versioneer_py)
+            )
     except NameError:
         pass
     return root
@@ -349,6 +352,7 @@ def get_config_from_root(root):
         if parser.has_option("versioneer", name):
             return parser.get("versioneer", name)
         return None
+
     cfg = VersioneerConfig()
     cfg.VCS = VCS
     cfg.style = get(parser, "style") or ""
@@ -373,17 +377,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -391,10 +396,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -419,7 +427,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY["git"] = '''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -994,7 +1002,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1003,7 +1011,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1011,19 +1019,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -1038,8 +1053,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -1047,10 +1061,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -1073,17 +1096,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -1092,10 +1114,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -1106,13 +1130,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -1168,16 +1192,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -1206,11 +1236,13 @@ def versions_from_file(filename):
             contents = f.read()
     except EnvironmentError:
         raise NotThisMethod("unable to read _version.py")
-    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
-                   contents, re.M | re.S)
+    mo = re.search(
+        r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+    )
     if not mo:
-        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
-                       contents, re.M | re.S)
+        mo = re.search(
+            r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+        )
     if not mo:
         raise NotThisMethod("no version_json in _version.py")
     return json.loads(mo.group(1))
@@ -1219,8 +1251,7 @@ def versions_from_file(filename):
 def write_to_version_file(filename, versions):
     """Write the given version number to the given _version.py file."""
     os.unlink(filename)
-    contents = json.dumps(versions, sort_keys=True,
-                          indent=1, separators=(",", ": "))
+    contents = json.dumps(versions, sort_keys=True, indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
@@ -1252,8 +1283,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1367,11 +1397,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -1391,9 +1423,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 class VersioneerBadRootError(Exception):
@@ -1416,8 +1452,9 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert cfg.versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
+    assert (
+        cfg.versionfile_source is not None
+    ), "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)
@@ -1471,9 +1508,13 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None, "error": "unable to compute version",
-            "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }
 
 
 def get_version():
@@ -1522,6 +1563,7 @@ def get_cmdclass():
             print(" date: %s" % vers.get("date"))
             if vers["error"]:
                 print(" error: %s" % vers["error"])
+
     cmds["version"] = cmd_version
 
     # we override "build_py" in both distutils and setuptools
@@ -1554,10 +1596,10 @@ def get_cmdclass():
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:
-                target_versionfile = os.path.join(self.build_lib,
-                                                  cfg.versionfile_build)
+                target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
                 print("UPDATING %s" % target_versionfile)
                 write_to_version_file(target_versionfile, versions)
+
     cmds["build_py"] = cmd_build_py
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
@@ -1582,17 +1624,21 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["build_exe"] = cmd_build_exe
         del cmds["build_py"]
 
-    if 'py2exe' in sys.modules:  # py2exe enabled?
+    if "py2exe" in sys.modules:  # py2exe enabled?
         try:
             from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
         except ImportError:
@@ -1611,13 +1657,17 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["py2exe"] = cmd_py2exe
 
     # we override different "sdist" commands for both environments
@@ -1644,8 +1694,10 @@ def get_cmdclass():
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
             print("UPDATING %s" % target_versionfile)
-            write_to_version_file(target_versionfile,
-                                  self._versioneer_generated_versions)
+            write_to_version_file(
+                target_versionfile, self._versioneer_generated_versions
+            )
+
     cmds["sdist"] = cmd_sdist
 
     return cmds
@@ -1700,11 +1752,13 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (
+        EnvironmentError,
+        configparser.NoSectionError,
+        configparser.NoOptionError,
+    ) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
-            print("Adding sample versioneer config to setup.cfg",
-                  file=sys.stderr)
+            print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
@@ -1713,15 +1767,18 @@ def do_setup():
     print(" creating %s" % cfg.versionfile_source)
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
-        f.write(LONG % {"DOLLAR": "$",
-                        "STYLE": cfg.style,
-                        "TAG_PREFIX": cfg.tag_prefix,
-                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                        })
+        f.write(
+            LONG
+            % {
+                "DOLLAR": "$",
+                "STYLE": cfg.style,
+                "TAG_PREFIX": cfg.tag_prefix,
+                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                "VERSIONFILE_SOURCE": cfg.versionfile_source,
+            }
+        )
 
-    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
-                       "__init__.py")
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -1763,8 +1820,10 @@ def do_setup():
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
+        print(
+            " appending versionfile_source ('%s') to MANIFEST.in"
+            % cfg.versionfile_source
+        )
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)
     else:


### PR DESCRIPTION
I started using ruff for my Python projects some time ago and I really like it. I automatically runs Python's formatter Black, isort and can automatically fix a whole host of flake-8 issues. 

Currently it is annoying to develop new pre-commits, because of all the flake-8 violations. With this tool it takes care of most of it.

The disadvantage is that you have to run it once and it makes a lot of changes. Although these can be ignored as explained [here](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame).