### PR TITLE
FIX: encoding issues with files on windows, better error reporting on twincat-lineids-remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ repos:
         files: \.(TcPOU|TcDUT|TcGVL)$
 
 -   repo: https://github.com/pcdshub/pre-commit-hooks.git
-    rev: v1.7.0
+    rev: v1.7.1
     hooks:
     -   id: twincat-leading-tabs-remover
     -   id: twincat-lineids-remover

--- a/forTwinCatRepos/.pre-commit-config.yaml
+++ b/forTwinCatRepos/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         files: \.(TcPOU|TcDUT|TcGVL)$
 
 -   repo: https://github.com/pcdshub/pre-commit-hooks.git
-    rev: v1.7.0
+    rev: v1.7.1
     hooks:
     -   id: twincat-leading-tabs-remover
     -   id: twincat-lineids-remover

--- a/pre_commit_hooks/check_twincat_versions.py
+++ b/pre_commit_hooks/check_twincat_versions.py
@@ -71,7 +71,7 @@ def main(args=None):
         versions = {}
         pinned = {}
         for filename in args.filenames:
-            with open(filename, "r") as file:
+            with open(filename, "r", encoding="utf-8") as file:
                 xml_content = file.read()
                 versions[filename] = get_tc_version(xml_content)
                 pinned[filename] = tc_version_pinned(xml_content)
@@ -86,10 +86,10 @@ def main(args=None):
                 reason_msg = f"\nReason: {args.reason}" if args.reason else ""
                 if args.fix:
                     for filename in mismatched_files:
-                        with open(filename, "r") as file:
+                        with open(filename, "r", encoding="utf-8") as file:
                             xml_content = file.read()
                         fixed_content = fix_tc_version(xml_content, args.target_version)
-                        with open(filename, "w") as file:
+                        with open(filename, "w", encoding="utf-8") as file:
                             file.write(fixed_content)
 
                     print(
@@ -116,10 +116,10 @@ def main(args=None):
             if mismatched_files:
                 if args.fix:
                     for filename in mismatched_files:
-                        with open(filename, "r") as file:
+                        with open(filename, "r", encoding="utf-8") as file:
                             xml_content = file.read()
                         fixed_content = fix_pinned_version(xml_content, args.pinned)
-                        with open(filename, "w") as file:
+                        with open(filename, "w", encoding="utf-8") as file:
                             file.write(fixed_content)
                     print(
                         f"Fixed pinned state for:{itemize}{itemize.join(mismatched_files)}"

--- a/pre_commit_hooks/leading_tabs_remover.py
+++ b/pre_commit_hooks/leading_tabs_remover.py
@@ -7,7 +7,7 @@ TAB_WIDTH = 4
 
 
 def fix_file(filename, tab_width=TAB_WIDTH):
-    with open(filename, "r") as fd:
+    with open(filename, "r", encoding="utf-8") as fd:
         original_lines = fd.readlines()
     new_lines = []
     changed = False
@@ -24,7 +24,7 @@ def fix_file(filename, tab_width=TAB_WIDTH):
         new_lines.append(line)
     if changed:
         print(f"Fixing {filename}")
-        with open(filename, "w") as fd:
+        with open(filename, "w", encoding="utf-8") as fd:
             fd.write("".join(new_lines))
 
 

--- a/pre_commit_hooks/twincat_lineids_remover.py
+++ b/pre_commit_hooks/twincat_lineids_remover.py
@@ -4,7 +4,7 @@ import argparse
 
 
 def fix_file(filename):
-    with open(filename, "r") as fd:
+    with open(filename, "r", encoding="utf-8") as fd:
         original_lines = fd.readlines()
     new_lines = []
     changed = False
@@ -17,7 +17,7 @@ def fix_file(filename):
 
     if changed:
         print(f"Fixing {filename}")
-        with open(filename, "w") as fd:
+        with open(filename, "w", encoding="utf-8") as fd:
             fd.write("".join(new_lines))
 
 
@@ -26,11 +26,14 @@ def main(args=None):
         parser = argparse.ArgumentParser()
         parser.add_argument("filenames", nargs="*")
         args = parser.parse_args()
+    filename = None
     try:
         for filename in args.filenames:
             fix_file(filename)
         return 0
     except Exception as exc:
+        if filename is not None:
+            print(f"Error while processing {filename}")
         print(exc)
         return 1
 


### PR DESCRIPTION
When you open a file on Windows using Python, the default encoding is not utf-8, so it is not guaranteed to be able to decode special characters (for some definition of special).

See #32 for an example.

This patch changes all instances of `open` (except those that open files in binary mode) to include `utf-8` as the encoding.
It also updates the twincat-lineids-remover hook to tell us which file had the issue if it has an error processing a file.

I've bumped the example version numbers to v1.7.1 in anticipation of a tag.

closes #32 