### PR TITLE
Added printing out of filename parsed to check_fixed_library_versions.py

### DIFF
--- a/pre_commit_hooks/check_fixed_library_versions.py
+++ b/pre_commit_hooks/check_fixed_library_versions.py
@@ -24,13 +24,15 @@ def check_file(filename):
     non_fixed_library_versions = added_libraries - fixed_version_libraries
 
     if len(non_fixed_library_versions) == 1:
-        raise PreCommitException(
-            f"Library version of {list(non_fixed_library_versions)[0]} is not fixed!"
-        )
+        raise PreCommitException((
+            f"Library version of {list(non_fixed_library_versions)[0]} is "
+            f"not fixed! File parsed: {filename}"
+        ))
     elif len(non_fixed_library_versions) > 1:
-        raise PreCommitException(
-            f"Library version of {', '.join(non_fixed_library_versions)} are not fixed!"
-        )
+        raise PreCommitException((
+            f"Library version of {', '.join(non_fixed_library_versions)} "
+            f"are not fixed! File parsed: {filename}"
+        ))
 
 
 def main(args=None):


### PR DESCRIPTION
- If the check fails, then now prints out the filename it parsed so the user can have an easier time noticing if it is evaluating the wrong plcproj file.
- Noticed numerous flake8 issues and lack of even basic unit tests for most checks. Need to circle back later.